### PR TITLE
Add explicit backend listening address.

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -107,6 +107,6 @@ setInterval(pollPlayerCount, 30000);
 latencyMonitor.start(30000);
 
 const PORT = process.env.PORT || 3001;
-httpServer.listen(PORT, 0.0.0.0, () => { // todo: make configurable?
+httpServer.listen(PORT, '0.0.0.0', () => { // todo: make configurable?
   console.log(`AzerothCore Dashboard backend running on http://0.0.0.0:${PORT}`);
 });


### PR DESCRIPTION
This allows the backend to be accessed/queried from other machines.