### PR TITLE
Support comma-separated frontend CORS origins

### DIFF
--- a/backend/middleware/ipAllowlist.js
+++ b/backend/middleware/ipAllowlist.js
@@ -26,9 +26,10 @@ function parseAllowlist() {
   return [...expanded];
 }
 
-const allowlist = parseAllowlist();
-
 function ipAllowlist(req, res, next) {
+  // Re-read process.env each request so changes made via the .env editor take
+  // effect immediately without requiring a server restart.
+  const allowlist = parseAllowlist();
   // req.ip honours the Express `trust proxy` setting; fall back to socket address.
   const ip = req.ip || req.socket?.remoteAddress || '';
   if (allowlist.includes(ip)) return next();

--- a/backend/server.js
+++ b/backend/server.js
@@ -55,16 +55,24 @@ const dbc = require('./dbc');
 const app = express();
 const httpServer = http.createServer(app);
 
-// Support comma-separated origins so both localhost and LAN IPs work simultaneously
-const rawFrontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
-const frontendOrigins = rawFrontendUrl.split(',').map((s) => s.trim()).filter(Boolean);
-const frontendUrl = frontendOrigins.length === 1 ? frontendOrigins[0] : frontendOrigins;
+// Re-read FRONTEND_URL from process.env each time so changes via the .env editor
+// take effect immediately without a server restart.
+function getFrontendOrigins() {
+  const raw = process.env.FRONTEND_URL || 'http://localhost:5173';
+  return raw.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function dynamicOrigin(origin, callback) {
+  const allowed = getFrontendOrigins();
+  if (!origin || allowed.includes(origin)) return callback(null, true);
+  callback(new Error('Not allowed by CORS'));
+}
 
 const io = new Server(httpServer, {
-  cors: { origin: frontendUrl, methods: ['GET', 'POST'] },
+  cors: { origin: dynamicOrigin, methods: ['GET', 'POST'] },
 });
 
-app.use(cors({ origin: frontendUrl }));
+app.use(cors({ origin: dynamicOrigin }));
 app.use(express.json({ limit: '10mb' }));
 app.use(ipAllowlist);
 
@@ -275,5 +283,5 @@ startRetentionJob();
 const PORT = process.env.PORT || 3001;
 httpServer.listen(PORT, '0.0.0.0', () => {
   console.log(`AzerothCore Dashboard backend listening on port ${PORT}`);
-  console.log(`  Frontend: ${frontendUrl}`);
+  console.log(`  Frontend: ${getFrontendOrigins().join(', ')}`);
 });


### PR DESCRIPTION
Allow the FRONTEND_URL env var to contain comma-separated origins (e.g. localhost and LAN IP). Parse the value with split/trim/filter and pass an array to socket.io when multiple origins are provided; keep a single string for a single origin. Retains the default http://localhost:5173.

Restart the backend after this change. Two things were fixed:

- **CORS**: `FRONTEND_URL` now accepts comma-separated origins. Both `localhost:5173` and `192.168.1.138:5173` are allowed, so it works from either the server machine or the LAN.
- **IP Allowlist**: Added `192.168.1.138` to `ALLOWED_IPS` so the backend accepts requests coming from that address.

If you're accessing from a *different* LAN machine (e.g. your PC at `192.168.1.50` connecting to the server at `192.168.1.138`), also add your client IP to `ALLOWED_IPS`:

```
ALLOWED_IPS=127.0.0.1,::1,192.168.1.138,192.168.1.50
```